### PR TITLE
feat: meizhi feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.vscode/
+
 # Built Files & Log
 .build/
 dist/

--- a/build/prepare.js
+++ b/build/prepare.js
@@ -27,6 +27,7 @@ const compilerOptionsBase = {
     experimentalDecorators: true,
     // emitDecoratorMetadata: true,
     incremental: true,
+    lib: ['ES2022', 'ES2022.error'],
 };
 const baseOutDir = path.resolve(__dirname, '../.cache/ts-out');
 const config = {

--- a/package.json
+++ b/package.json
@@ -70,5 +70,8 @@
     },
     "lint-staged": {
         "*.{js,jsx,ts,tsx,json}": "prettier --write"
+    },
+    "dependencies": {
+        "alipay-sdk": "^4.11.0"
     }
 }

--- a/package.json
+++ b/package.json
@@ -70,9 +70,5 @@
     },
     "lint-staged": {
         "*.{js,jsx,ts,tsx,json}": "prettier --write"
-    },
-    "dependencies": {
-        "alipay-sdk": "^4.11.0",
-        "wechatpay-node-v3": "2.1.8"
     }
 }

--- a/packages/codemate-plugin/api.ts
+++ b/packages/codemate-plugin/api.ts
@@ -3,5 +3,5 @@ import { Logger } from 'hydrooj';
 export * from './plugins/privilege-group/model';
 export * as plist from './plugins/assign-problem-list/model';
 export * as bulletin from './plugins/bulletin/model';
-
+export * as meiValue from './plugins/mei-value/model';
 export const logger = new Logger('codemate');

--- a/packages/codemate-plugin/package.json
+++ b/packages/codemate-plugin/package.json
@@ -2,13 +2,15 @@
     "name": "codemate-plugin",
     "packageManager": "yarn@4.0.2",
     "dependencies": {
+        "alipay-sdk": "^4.11.0",
         "crypto-js": "^4.2.0",
         "fs-extra": "^11.2.0",
         "hydrooj": "workspace:^",
         "lodash": "^4.17.21",
         "lru-cache": "^10.2.0",
         "nanoid": "^5.0.6",
-        "tencentcloud-sdk-nodejs-captcha": "^4.0.850"
+        "tencentcloud-sdk-nodejs-captcha": "^4.0.850",
+        "wechatpay-node-v3": "2.1.8"
     },
     "module": "api.ts",
     "main": "api.ts",

--- a/packages/codemate-plugin/plugins/mei-value/index.ts
+++ b/packages/codemate-plugin/plugins/mei-value/index.ts
@@ -1,0 +1,241 @@
+import { Context, Handler, ObjectId, OplogModel, param, query, Types, UserModel, UserNotFoundError } from 'hydrooj';
+import { AlipayCodemateSdk, ConsumeMeiValueResult, logger, OrderError } from './lib';
+import * as orderDoc from './model';
+
+declare module 'hydrooj' {
+    interface Udoc {
+        meiValue?: number;
+    }
+}
+
+const MEI_VALUE_RATIO = 10; // 10 meiValue = 1 RMB
+
+class MeiValueHandler extends Handler {
+    async prepare() {
+        if (this.user._id <= 1) throw new UserNotFoundError(this.user._id);
+        const udoc = await UserModel.getById(this.domain._id, this.user._id);
+        if (!udoc) throw new UserNotFoundError(this.user._id);
+    }
+
+    async get() {
+        const udoc = await UserModel.getById(this.domain._id, this.user._id);
+        if (!udoc) throw new UserNotFoundError(this.user._id);
+        const tradeInfo = await global.Hydro.lib.consumeMeiValue(this, this.user._id, this.domain._id, '测试交易', '测试交易信息', 80);
+        logger.info('trade', tradeInfo);
+        this.response.body = { meiValue: udoc._udoc.meiValue ?? 0 };
+    }
+}
+
+class MeiValueOrderHandler extends Handler {
+    async prepare() {
+        if (this.user._id <= 1) throw new UserNotFoundError(this.user._id);
+        const udoc = await UserModel.getById(this.domain._id, this.user._id);
+        if (!udoc) throw new UserNotFoundError(this.user._id);
+    }
+
+    @param('chargeCount', Types.PositiveInt)
+    async post(domainId: string, chargeCount: number) {
+        const udoc = await UserModel.getById(this.domain._id, this.user._id);
+        if (!udoc) throw new UserNotFoundError(this.user._id);
+        const chargeRMB = chargeCount / MEI_VALUE_RATIO;
+
+        // generate order
+        const orderSubject = `魅值下单：${chargeCount} 点`;
+        const orderDescription = `用户${this.user._id} 下单魅值 ${chargeCount} 点`;
+        const orderId = await orderDoc.add(domainId, this.user._id, orderSubject, orderDescription, chargeRMB, chargeCount);
+
+        await OplogModel.log(this, 'mei.order', {
+            orderId,
+            userId: this.user._id,
+            chargeCount,
+        });
+
+        logger.debug(`order: ${orderId}, subject: ${orderSubject}, desc: ${orderDescription}`);
+
+        this.response.body = {
+            success: true,
+            charge: chargeCount,
+            orderId,
+            orderSubject,
+            orderDescription,
+        };
+    }
+}
+
+async function checkAndRefreshCharge(domainId: string, orderId: ObjectId, paymentType: 'Alipay' | 'Wechat', _this: any) {
+    // validate payment
+    const order = await orderDoc.get(domainId, orderId);
+    if (order.isPaied) {
+        // already charged, return
+        return;
+    }
+    const userId = order.owner;
+
+    // not-paied orders should terminates here
+    const orderPartial: Partial<orderDoc.PaymentOrder> = {};
+    if (paymentType === 'Alipay') {
+        const alipaySdk = global.Hydro.lib.alipaySdk();
+        const feedback = await alipaySdk.queryFeedback(orderId.toString());
+        logger.debug('alipay sync feedback', feedback);
+        if (feedback['code'] !== '10000' || feedback['msg'] !== 'Success') {
+            throw new OrderError('订单尚未完成支付');
+        }
+        // payment: 'Pending' | 'Alipay' | 'Wechat';
+        // isPaied: Boolean;
+        // payAt?: Date;
+        // paymentInfo?: JSON;
+        orderPartial.payment = 'Alipay';
+        orderPartial.paymentInfo = feedback;
+    } else {
+        throw new OrderError('错误的支付类型');
+    }
+
+    // after payment check...
+    orderPartial.isPaied = true;
+    orderPartial.payAt = new Date();
+
+    // TODO: transaction here
+    // inc charge value
+    await OplogModel.log(_this, 'mei.chargeSuccessIncrement', {
+        orderId,
+        userId: _this.user._id,
+        chargeCount: order.totalMeiValue,
+        paymentType,
+    });
+    await UserModel.setById(userId, undefined, undefined, undefined, {
+        meiValue: order.totalMeiValue,
+    });
+    await orderDoc.set(domainId, orderId, orderPartial);
+}
+
+class MeiValuePayHandler extends Handler {
+    async prepare() {
+        if (this.user._id <= 1) throw new UserNotFoundError(this.user._id);
+        const udoc = await UserModel.getById(this.domain._id, this.user._id);
+        if (!udoc) throw new UserNotFoundError(this.user._id);
+    }
+
+    @query('orderId', Types.ObjectId, false)
+    async get(domainId: string, orderId: ObjectId) {
+        const udoc = await UserModel.getById(this.domain._id, this.user._id);
+        if (!udoc) throw new UserNotFoundError(this.user._id);
+
+        const order = await orderDoc.get(domainId, orderId);
+        if (order.isPaied) {
+            throw new OrderError('订单已经完成');
+        }
+
+        // generate_alipay_link
+        const alipaySdk = global.Hydro.lib.alipaySdk();
+        const alipayHtml = await alipaySdk.orderPay(orderId.toString(), order.totalRMBAmount, order.title);
+        logger.debug('alipay', alipayHtml);
+        this.response.body = {
+            success: true,
+            payment: {
+                alipayHtml,
+            },
+        };
+    }
+
+    @param('orderId', Types.ObjectId, false)
+    @param('paymentType', Types.String, false)
+    async post(domainId: string, orderId: ObjectId, paymentType: 'Alipay' | 'Wechat') {
+        const udoc = await UserModel.getById(this.domain._id, this.user._id);
+        if (!udoc) throw new UserNotFoundError(this.user._id);
+        await checkAndRefreshCharge(domainId, orderId, paymentType, this);
+        this.response.body = {
+            success: true,
+            msg: '更新充值状态成功',
+        };
+    }
+}
+
+class MeiValueNotifierAlipayHandler extends Handler {
+    @param('out_trade_no', Types.ObjectId, false)
+    async post(domainId: string, orderId: ObjectId) {
+        const sdk = global.Hydro.lib.alipaySdk();
+        const validate = sdk.alipaySdk.checkNotifySign(this.request.body);
+
+        logger.info(`alipay notified: ${orderId}, checkSign: ${validate}`);
+        if (validate) {
+            try {
+                logger.info(`sign validated success`);
+                checkAndRefreshCharge(domainId, orderId, 'Alipay', this);
+                this.response.body = 'success';
+            } catch (e) {
+                logger.info(`sign validated fail`);
+                this.response.body = 'fail';
+            }
+        } else {
+            this.response.body = 'fail';
+        }
+    }
+}
+
+export async function apply(ctx: Context) {
+    ctx.Route('mei_value', '/mei_value', MeiValueHandler);
+    ctx.Route('mei_value_order', '/mei_value/order', MeiValueOrderHandler);
+    ctx.Route('mei_value_pay', '/mei_value/pay', MeiValuePayHandler);
+    ctx.Route('mei_value_notifier_alipay', '/mei_value/notifier/alipay', MeiValueNotifierAlipayHandler);
+
+    ctx.inject(['kv'], async (c) => {
+        const alipayAppId = await c.kv.use('mei.alipay.appId');
+        alipayAppId.value ||= [''];
+        const alipayPrivateKey = await c.kv.use('mei.alipay.privateKey');
+        alipayPrivateKey.value ||= [''];
+        const alipayPublicKey = await c.kv.use('mei.alipay.alipayPublicKey');
+        alipayPrivateKey.value ||= [''];
+        const alipayEndpoint = await c.kv.use('mei.alipay.endpoint');
+        alipayEndpoint.value ||= [''];
+
+        global.Hydro.lib.alipaySdk = () => {
+            const alipayConfig = {
+                appId: alipayAppId.value[0],
+                gateway: alipayEndpoint.value[0],
+                privateKey: alipayPrivateKey.value[0],
+                alipayPublicKey: alipayPublicKey.value[0],
+            };
+            logger.info('ctx', ctx.domain);
+            logger.info('alipayConfig');
+            logger.info(alipayConfig);
+            return new AlipayCodemateSdk(alipayConfig);
+        };
+
+        global.Hydro.lib.consumeMeiValue = async (
+            handler: Handler,
+            userId: number,
+            domainId: string,
+            tradeSubject: string,
+            tradeComment: string,
+            tradeMeiValue: number,
+        ): Promise<ConsumeMeiValueResult> => {
+            if (tradeMeiValue < 0) {
+                return {
+                    success: false,
+                    msg: '消费魅值数量不得小于0',
+                };
+            }
+            const udoc = await UserModel.getById(domainId, userId);
+            if (!udoc) throw new UserNotFoundError(userId);
+            const meiValue = udoc._udoc.meiValue ?? 0;
+            if (meiValue < tradeMeiValue) {
+                return {
+                    success: false,
+                    msg: '魅值不足',
+                };
+            }
+            await UserModel.setById(userId, undefined, undefined, undefined, {
+                meiValue: -tradeMeiValue,
+            });
+            const logId = await OplogModel.log(handler, 'mei.consume', {
+                tradeSubject,
+                tradeComment,
+                tradeMeiValue,
+            });
+            return {
+                success: true,
+                tradeNo: logId,
+            };
+        };
+    });
+}

--- a/packages/codemate-plugin/plugins/mei-value/index.ts
+++ b/packages/codemate-plugin/plugins/mei-value/index.ts
@@ -20,8 +20,6 @@ class MeiValueHandler extends Handler {
     async get() {
         const udoc = await UserModel.getById(this.domain._id, this.user._id);
         if (!udoc) throw new UserNotFoundError(this.user._id);
-        const tradeInfo = await global.Hydro.lib.consumeMeiValue(this, this.user._id, this.domain._id, '测试交易', '测试交易信息', 80);
-        logger.info('trade', tradeInfo);
         this.response.body = { meiValue: udoc._udoc.meiValue ?? 0 };
     }
 }

--- a/packages/codemate-plugin/plugins/mei-value/index.ts
+++ b/packages/codemate-plugin/plugins/mei-value/index.ts
@@ -15,7 +15,6 @@ import {
 import { coll as oplogColl } from 'hydrooj/src/model/oplog';
 import { AlipayCodemateSdk, ConsumeMeiValueResult, logger, OrderError, OrderNotFoundError, WxpayCodemateSdk } from './lib';
 import { PaymentOrderDoc, PaymentOrderModel } from './model';
-import { log } from 'console';
 
 declare module 'hydrooj' {
     interface Udoc {

--- a/packages/codemate-plugin/plugins/mei-value/lib.ts
+++ b/packages/codemate-plugin/plugins/mei-value/lib.ts
@@ -1,4 +1,4 @@
-import { AlipaySdk, AlipaySdkConfig } from 'alipay-sdk';
+import { AlipaySdk, AlipaySdkConfig } from 'alipay-sdk'; // 1
 import { BadRequestError, Err, Handler, Logger, NotFoundError, ObjectID, SystemError } from 'hydrooj';
 
 export const logger = new Logger('meiValue');

--- a/packages/codemate-plugin/plugins/mei-value/lib.ts
+++ b/packages/codemate-plugin/plugins/mei-value/lib.ts
@@ -1,0 +1,65 @@
+import { AlipaySdk, AlipaySdkConfig } from 'alipay-sdk';
+import { BadRequestError, Err, Handler, Logger, NotFoundError, ObjectID, SystemError } from 'hydrooj';
+
+export const logger = new Logger('meiValue');
+export const AlipaySDKError = Err('AlipaySDKError', SystemError, 'Alipay sdk error: {0}');
+export const OrderNotFoundError = Err('OrderNotFoundError', NotFoundError, 'OrderId not found: {0}');
+export const OrderError = Err('OrderError', BadRequestError, 'OrderId cannot been paied: {0}');
+
+declare module 'hydrooj' {
+    interface Lib {
+        alipaySdk: () => AlipayCodemateSdk;
+        consumeMeiValue: (
+            handler: Handler,
+            userId: number,
+            domainId: string,
+            tradeSubject: string,
+            tradeComment: string,
+            tradeMeiValue: number,
+        ) => Promise<ConsumeMeiValueResult>;
+    }
+}
+
+export type ConsumeMeiValueResult =
+    | {
+        success: false;
+        msg: string;
+    }
+    | {
+        success: true;
+        tradeNo: ObjectID;
+    };
+
+export class AlipayCodemateSdk {
+    alipaySdk: AlipaySdk;
+    constructor(config: AlipaySdkConfig) {
+        try {
+            this.alipaySdk = new AlipaySdk(config);
+        } catch (err) {
+            throw new AlipaySDKError(err);
+        }
+    }
+
+    async orderPay(tradeNo: string, totalRMBAmount: number, subject: string) {
+        const result = this.alipaySdk.pageExec('alipay.trade.page.pay', {
+            biz_content: {
+                out_trade_no: tradeNo,
+                total_amount: totalRMBAmount,
+                subject,
+                product_code: 'FAST_INSTANT_TRADE_PAY',
+            },
+            notify_url: 'http://pc-11-302.jinyuchata.top:18888/mei_value/notifier/alipay',
+        });
+        return result;
+    }
+
+    async queryFeedback(tradeNo: string) {
+        const result = await this.alipaySdk.exec('alipay.trade.query', {
+            biz_content: {
+                out_trade_no: tradeNo,
+            },
+        });
+        logger.debug(result);
+        return result;
+    }
+}

--- a/packages/codemate-plugin/plugins/mei-value/lib.ts
+++ b/packages/codemate-plugin/plugins/mei-value/lib.ts
@@ -22,13 +22,13 @@ declare module 'hydrooj' {
 
 export type ConsumeMeiValueResult =
     | {
-        success: false;
-        msg: string;
-    }
+          success: false;
+          msg: string;
+      }
     | {
-        success: true;
-        tradeNo: ObjectID;
-    };
+          success: true;
+          tradeNo: ObjectID;
+      };
 
 export class AlipayCodemateSdk {
     alipaySdk: AlipaySdk;

--- a/packages/codemate-plugin/plugins/mei-value/lib.ts
+++ b/packages/codemate-plugin/plugins/mei-value/lib.ts
@@ -1,4 +1,3 @@
-// @ts-expect-error alipay-sdk has no type declaration
 import { AlipaySdk, AlipaySdkConfig } from 'alipay-sdk';
 import { BadRequestError, Err, Handler, Logger, NotFoundError, ObjectID, SystemError } from 'hydrooj';
 

--- a/packages/codemate-plugin/plugins/mei-value/lib.ts
+++ b/packages/codemate-plugin/plugins/mei-value/lib.ts
@@ -1,6 +1,4 @@
-import fs from 'fs';
-import { AlipaySdk, AlipaySdkConfig } from 'alipay-sdk'; // 1
-import request from 'superagent';
+import { AlipaySdk, AlipaySdkConfig } from 'alipay-sdk';
 import WxPay from 'wechatpay-node-v3';
 import { BadRequestError, Err, Handler, Logger, NotFoundError, ObjectID, SystemError } from 'hydrooj';
 

--- a/packages/codemate-plugin/plugins/mei-value/lib.ts
+++ b/packages/codemate-plugin/plugins/mei-value/lib.ts
@@ -1,3 +1,4 @@
+// @ts-expect-error alipay-sdk has no type declaration
 import { AlipaySdk, AlipaySdkConfig } from 'alipay-sdk';
 import { BadRequestError, Err, Handler, Logger, NotFoundError, ObjectID, SystemError } from 'hydrooj';
 

--- a/packages/codemate-plugin/plugins/mei-value/model.ts
+++ b/packages/codemate-plugin/plugins/mei-value/model.ts
@@ -1,0 +1,47 @@
+import { Document, DocumentModel as document, ObjectId, Projection } from 'hydrooj';
+import { OrderNotFoundError } from './lib';
+
+const TYPE_ORDER = document.TYPE_ORDER;
+
+export interface PaymentOrder extends Document {
+    docId: ObjectId;
+    docType: typeof TYPE_ORDER;
+    title: string; // subject
+    content: string; // description
+    owner: number;
+
+    // 下单相关
+    totalRMBAmount: number;
+    totalMeiValue: number;
+    orderAt: Date;
+
+    // 支付相关
+    payment: 'Pending' | 'Alipay' | 'Wechat';
+    isPaied: Boolean;
+    payAt?: Date;
+    paymentInfo?: any;
+}
+
+export async function add(domainId: string, userOwner: number, subject: string, description: string, totalRMBAmount: number, totalMeiValue: number) {
+    const res = await document.add(domainId, subject, userOwner, TYPE_ORDER, null, null, null, {
+        title: subject,
+        content: description,
+        totalRMBAmount,
+        totalMeiValue,
+        orderAt: new Date(),
+        payment: 'Pending',
+        isPaied: false,
+    });
+    return res;
+}
+
+export async function get(domainId: string, orderId: ObjectId, projection?: Projection<PaymentOrder>): Promise<PaymentOrder> {
+    const tdoc = await document.get(domainId, TYPE_ORDER, orderId, projection);
+    if (!tdoc) throw new OrderNotFoundError(orderId);
+    return tdoc;
+}
+
+export async function set(domainId: string, orderId: ObjectId, $set: Partial<PaymentOrder>) {
+    const r = await document.set(domainId, TYPE_ORDER, orderId, $set);
+    return r;
+}

--- a/packages/codemate-plugin/plugins/mei-value/model.ts
+++ b/packages/codemate-plugin/plugins/mei-value/model.ts
@@ -1,4 +1,4 @@
-import { db, ObjectId } from 'hydrooj';
+import { type Collections, db, ObjectId } from 'hydrooj';
 
 export interface PaymentOrderDoc {
     _id: ObjectId;
@@ -23,13 +23,12 @@ declare module 'hydrooj' {
     interface Collections {
         order: PaymentOrderDoc;
     }
-
     interface Model {
         order: PaymentOrderModel;
     }
 }
 
-export const collOrder = db.collection('order');
+export const collOrder = db.collection('order' as keyof Collections);
 
 export class PaymentOrderModel {
     static async add(domainId: string, userOwner: number, subject: string, description: string, totalRMBAmount: number, totalMeiValue: number) {

--- a/packages/codemate-plugin/plugins/user-plist/index.ts
+++ b/packages/codemate-plugin/plugins/user-plist/index.ts
@@ -1,0 +1,107 @@
+import { Context, Handler, ObjectId, paginate, param, PermissionError, PRIV, ProblemModel, route, Types, ValidationError } from 'hydrooj';
+import * as ProblemListModel from '../assign-problem-list/model';
+
+class UserProblemListHandler extends Handler {
+    @param('page', Types.Int, true)
+    @param('all', Types.Boolean, true)
+    @param('pageSize', Types.Int, true)
+    async get(domainId: string, page: number = 1, all: boolean = false, pageSize = 10) {
+        if (all) this.checkPriv(PRIV.PRIV_VIEW_USER_SECRET); // allow super-admin to view all the problems
+        if (pageSize > 20) pageSize = 20;
+        const cursor = ProblemListModel.getMulti(domainId, {
+            visibility: 'private',
+            owner: this.user._id,
+        });
+        const [pldocs, pldocsPage, pldocsCount] = await paginate(cursor, page, pageSize);
+        this.response.body = {
+            pldocs,
+            pldocsPage,
+            pldocsCount,
+        };
+    }
+}
+
+class UserProblemListDetailHandler extends Handler {
+    @route('tid', Types.ObjectId)
+    @param('page', Types.Int, true)
+    @param('pageSize', Types.Int, true)
+    async get(domainId: string, tid: ObjectId, page = 1, pageSize = 10) {
+        const pldoc = await ProblemListModel.get(domainId, tid);
+        if (this.user._id !== pldoc.owner) this.checkPriv(PRIV.PRIV_VIEW_USER_SECRET);
+        for (const pid of pldoc.pids) {
+            // eslint-disable-next-line no-await-in-loop
+            if (!ProblemModel.canViewBy(await ProblemModel.get(domainId, pid), this.user)) throw new PermissionError();
+        }
+        const itemCount = pldoc.pids.length;
+        const pageCount = Math.ceil(pldoc.pids.length / 10);
+        pldoc.pids = pldoc.pids.slice((page - 1) * pageSize, page * pageSize - 1);
+        const pdict = await ProblemModel.getList(domainId, pldoc.pids);
+        this.response.body = {
+            pldoc,
+            pdict,
+            pageCount,
+            itemCount,
+            pageSize,
+            page,
+        };
+    }
+}
+
+class UserProblemListEditHandler extends Handler {
+    @route('tid', Types.ObjectId)
+    @param('insertPids', Types.NumericArray)
+    @param('deletePids', Types.NumericArray)
+    @param('title', Types.String)
+    @param('content', Types.String)
+    async post(domainId: string, tid: ObjectId, insertPids: number[], deletePids: number[], title: string, content: string) {
+        const pldoc = await ProblemListModel.get(domainId, tid);
+        if (pldoc.owner !== this.user._id) this.checkPriv(PRIV.PRIV_VIEW_USER_SECRET);
+        for (const pid of insertPids) {
+            // eslint-disable-next-line no-await-in-loop
+            const pdoc = await ProblemModel.get(domainId, pid);
+            if (!pdoc || !ProblemModel.canViewBy(pdoc, this.user)) throw new PermissionError();
+            if (pldoc.pids.includes(pid)) throw new ValidationError(insertPids, null, `Duplicate problem ${pid}.`);
+        }
+        for (const pid of deletePids) {
+            if (!pldoc.pids.includes(pid)) throw new ValidationError(deletePids, null, `Problem ${pid} does not exist.`);
+        }
+        const pids = pldoc.pids.concat(insertPids).filter((pid) => !deletePids.includes(pid));
+        await ProblemListModel.edit(domainId, tid, {
+            pids,
+            title,
+            content,
+        });
+        this.response.body = {
+            success: true,
+        };
+    }
+}
+
+class UserProblemListCreateHandler extends Handler {
+    @param('title', Types.String)
+    @param('content', Types.String)
+    async post(domainId: string, title: string, content: string) {
+        const tid = await ProblemListModel.add(domainId, title, content, this.user._id, 'private', []);
+        this.response.body = { tid };
+    }
+}
+
+class UserProblemListDeleteHandler extends Handler {
+    @route('tid', Types.ObjectId)
+    async post(domainId: string, tid: ObjectId) {
+        const pldoc = await ProblemListModel.get(domainId, tid);
+        if (pldoc.owner !== this.user._id) this.checkPriv(PRIV.PRIV_VIEW_USER_SECRET);
+        await ProblemListModel.del(domainId, tid);
+        this.response.body = {
+            success: true,
+        };
+    }
+}
+
+export async function apply(ctx: Context) {
+    ctx.Route('user_problem_list', '/user-plist', UserProblemListHandler, PRIV.PRIV_USER_PROFILE);
+    ctx.Route('user_problem_list_create', '/user-plist/create', UserProblemListCreateHandler, PRIV.PRIV_USER_PROFILE);
+    ctx.Route('user_problem_list_detail', '/user-plist/:tid/detail', UserProblemListDetailHandler, PRIV.PRIV_USER_PROFILE);
+    ctx.Route('user_problem_list_edit', '/user-plist/:tid/edit', UserProblemListEditHandler, PRIV.PRIV_USER_PROFILE);
+    ctx.Route('user_problem_list_delete', '/user-plist/:tid/delete', UserProblemListDeleteHandler, PRIV.PRIV_USER_PROFILE);
+}

--- a/packages/hydrooj/src/model/document.ts
+++ b/packages/hydrooj/src/model/document.ts
@@ -552,4 +552,5 @@ global.Hydro.model.document = {
     TYPE_PROBLEM_SOLUTION,
     TYPE_TRAINING,
     TYPE_BULLETIN,
+    TYPE_ORDER,
 };

--- a/packages/hydrooj/src/model/document.ts
+++ b/packages/hydrooj/src/model/document.ts
@@ -1,6 +1,6 @@
 /* eslint-disable object-curly-newline */
 import assert from 'assert';
-import { bulletin, plist } from 'codemate-plugin';
+import { bulletin, meiValue, plist } from 'codemate-plugin';
 import { Filter, FindCursor, ObjectId, OnlyFieldsOfType, PushOperator, UpdateFilter } from 'mongodb';
 import { Context } from '../context';
 import { Content, ContestClarificationDoc, DiscussionDoc, DiscussionReplyDoc, ProblemDoc, ProblemStatusDoc, Tdoc, TrainingDoc } from '../interface';
@@ -29,6 +29,7 @@ export const TYPE_TRAINING: 40 = 40;
 /** @deprecated use `TYPE_CONTEST` with rule `homework` instead. */
 export const TYPE_HOMEWORK: 60 = 60;
 export const TYPE_BULLETIN: 80 = 80;
+export const TYPE_ORDER: 100 = 100;
 
 export interface DocType {
     [TYPE_PROBLEM]: ProblemDoc;
@@ -42,6 +43,7 @@ export interface DocType {
     [TYPE_TRAINING]: TrainingDoc;
     [TYPE_SYSTEM_PLIST]: plist.ProblemList;
     [TYPE_BULLETIN]: bulletin.BulletinDoc;
+    [TYPE_ORDER]: meiValue.PaymentOrder;
 }
 
 export interface DocStatusType {

--- a/packages/hydrooj/src/model/user.ts
+++ b/packages/hydrooj/src/model/user.ts
@@ -270,12 +270,13 @@ class UserModel {
     }
 
     @ArgMethod
-    static async setById(uid: number, $set?: Partial<Udoc>, $unset?: Value<Partial<Udoc>, ''>, $push?: any) {
+    static async setById(uid: number, $set?: Partial<Udoc>, $unset?: Value<Partial<Udoc>, ''>, $push?: any, $inc?: any) {
         if (uid < -999) return null;
         const op: any = {};
         if ($set && Object.keys($set).length) op.$set = $set;
         if ($unset && Object.keys($unset).length) op.$unset = $unset;
         if ($push && Object.keys($push).length) op.$push = $push;
+        if ($inc && Object.keys($inc).length) op.$inc = $inc;
         if (op.$set?.loginip) op.$addToSet = { ip: op.$set.loginip };
         const keys = new Set(Object.values(op).flatMap((i) => Object.keys(i)));
         if (keys.has('mailLower') || keys.has('unameLower')) {

--- a/packages/hydrooj/src/service/server.ts
+++ b/packages/hydrooj/src/service/server.ts
@@ -359,7 +359,7 @@ async function handle(ctx: KoaContext, HandlerClass, checker) {
 const Checker = (permPrivChecker) => {
     let perm: bigint;
     let priv: number;
-    let checker = () => {};
+    let checker = () => { };
     for (const item of permPrivChecker) {
         if (typeof item === 'object') {
             if (typeof item.call !== 'undefined') {
@@ -507,7 +507,7 @@ class NotFoundHandler extends Handler {
         throw new NotFoundError(this.request.path);
     }
 
-    all() {}
+    all() { }
 }
 
 export class RouteService extends Service {
@@ -640,7 +640,14 @@ ${ctx.response.status} ${endTime - startTime}ms ${ctx.response.length}`);
     });
     const jsonCheckLayer = async (ctx: KoaContext, next: Next) => {
         const { user, request } = ctx.HydroContext;
-        const allowPaths = [/^\/login/, /^\/logout/, /^\/constant\/\w*/, /^\/lazy\/\w*\/\w*/, /^\/resource\/\w*\/\w*/];
+        const allowPaths = [
+            /^\/login/,
+            /^\/logout/,
+            /^\/constant\/\w*/,
+            /^\/lazy\/\w*\/\w*/,
+            /^\/resource\/\w*\/\w*/,
+            /^\/mei_value\/notifier\/alipay/,
+        ];
         if (allowPaths.some((p) => p.test(request.path)) || request.json || user.hasPriv(PRIV.PRIV_EDIT_SYSTEM)) {
             await next();
             return;
@@ -660,11 +667,11 @@ ${ctx.response.status} ${endTime - startTime}ms ${ctx.response.length}`);
             logger.warn('Websocket Error: %s', err.message);
             try {
                 socket.close(1003, 'Websocket Error');
-            } catch (e) {}
+            } catch (e) { }
         });
         socket.pause();
         const ctx: any = app.createContext(request, {} as any);
-        await domainLayer(ctx, () => baseLayer(ctx, () => layers[1](ctx, () => userLayer(ctx, () => {}))));
+        await domainLayer(ctx, () => baseLayer(ctx, () => layers[1](ctx, () => userLayer(ctx, () => { }))));
         for (const manager of router.wsStack) {
             if (manager.accept(socket, request, ctx)) return;
         }

--- a/packages/hydrooj/src/service/server.ts
+++ b/packages/hydrooj/src/service/server.ts
@@ -359,7 +359,7 @@ async function handle(ctx: KoaContext, HandlerClass, checker) {
 const Checker = (permPrivChecker) => {
     let perm: bigint;
     let priv: number;
-    let checker = () => { };
+    let checker = () => {};
     for (const item of permPrivChecker) {
         if (typeof item === 'object') {
             if (typeof item.call !== 'undefined') {
@@ -507,7 +507,7 @@ class NotFoundHandler extends Handler {
         throw new NotFoundError(this.request.path);
     }
 
-    all() { }
+    all() {}
 }
 
 export class RouteService extends Service {
@@ -667,11 +667,11 @@ ${ctx.response.status} ${endTime - startTime}ms ${ctx.response.length}`);
             logger.warn('Websocket Error: %s', err.message);
             try {
                 socket.close(1003, 'Websocket Error');
-            } catch (e) { }
+            } catch (e) {}
         });
         socket.pause();
         const ctx: any = app.createContext(request, {} as any);
-        await domainLayer(ctx, () => baseLayer(ctx, () => layers[1](ctx, () => userLayer(ctx, () => { }))));
+        await domainLayer(ctx, () => baseLayer(ctx, () => layers[1](ctx, () => userLayer(ctx, () => {}))));
         for (const manager of router.wsStack) {
             if (manager.accept(socket, request, ctx)) return;
         }

--- a/packages/onsite-toolkit/index.ts
+++ b/packages/onsite-toolkit/index.ts
@@ -1,4 +1,4 @@
-import { Context, db, ForbiddenError, UserModel } from 'hydrooj';
+import { Context, db, ForbiddenError, UserModel, Collections } from 'hydrooj';
 
 interface IpLoginInfo {
     _id: string;
@@ -10,7 +10,7 @@ declare module 'hydrooj' {
         iplogin: IpLoginInfo;
     }
 }
-const coll = db.collection('iplogin');
+const coll = db.collection('iplogin' as keyof Collections);
 
 function normalizeIp(ip: string) {
     if (ip.startsWith('::ffff:')) return ip.slice(7);

--- a/packages/vjudge/src/index.ts
+++ b/packages/vjudge/src/index.ts
@@ -14,11 +14,12 @@ import {
     STATUS,
     TaskModel,
     Time,
+    type Collections,
 } from 'hydrooj';
 import { BasicProvider, IBasicProvider, RemoteAccount } from './interface';
 import providers from './providers/index';
 
-const coll = db.collection('vjudge');
+const coll = db.collection('vjudge' as keyof Collections);
 const logger = new Logger('vjudge');
 const syncing = {};
 


### PR DESCRIPTION
add meizhi api, updated on apifox

## 魅值查询

1. `GET /mei_value`

## 魅值充值

1. `POST /mei_value/order` 下充值订单
2. `GET /mei_value/pay` 根据Step1返回的OrderId，获取支付宝/微信充值链接（目前只支持支付宝）
3. 用户通过Step2获取的链接，点开后用户自主完成充值。充值成功后，支付宝回调系统，会更新支付状态并为用户添加魅值
4. `POST /mei_value/pay` （可选）如果支付回调失败，也可以主动查询并更新充值状态。可以在跳转支付后，给用户提供“我已充值”按钮，调用此API主动查询支付状态

## 其他信息

- 已经接入OpLog
- 已经接入kv-service： "mei.alipay.appId"，"mei.alipay.privateKey"，"mei.alipay.alipayPublicKey"，"mei.alipay.endpoint"，"mei.alipay.alipayEndpoint"
- 目前支持支付宝、微信