### PR TITLE
feat: meizhi order query and alipay notify url configuration

### DIFF
--- a/packages/codemate-plugin/plugins/mei-value/lib.ts
+++ b/packages/codemate-plugin/plugins/mei-value/lib.ts
@@ -35,9 +35,11 @@ export type ConsumeMeiValueResult =
 
 export class AlipayCodemateSdk {
     alipaySdk: AlipaySdk;
-    constructor(config: AlipaySdkConfig) {
+    notifier: string;
+    constructor(config: AlipaySdkConfig, notifier: string) {
         try {
             this.alipaySdk = new AlipaySdk(config);
+            this.notifier = notifier;
         } catch (err) {
             throw new AlipaySDKError(err);
         }
@@ -52,7 +54,7 @@ export class AlipayCodemateSdk {
                 subject,
                 product_code: 'FAST_INSTANT_TRADE_PAY',
             },
-            notify_url: 'http://pc-11-302.jinyuchata.top:18888/mei_value/notifier/alipay',
+            notify_url: this.notifier,
         });
         return result;
     }


### PR DESCRIPTION
## Order Query

- `/mei_value/order?orderId=xxxx`, 返回订单当前状态, 可用于前端轮询

<img width="1014" alt="image" src="https://github.com/user-attachments/assets/a01b471d-b20c-4bc1-ba1c-67018c26fb17">


## Notify URL Configuration

将支付宝/微信回调均放入数据库的配置中

- 支付宝：KEY=mei.alipay.alipayNotifer, EXAMPLE_VAL=https://aioj.jinyuchata.top:31900/mei_value/notifier/alipay
- 微信：KEY=mei.wxpay.wxpayNotifer, EXAMPLE_VAL=https://aioj.jinyuchata.top:31900/mei_value/notifier/wx
