### PR TITLE
feat: json config for problem tag filter

### DIFF
--- a/packages/codemate-plugin/plugins/tags-config/index.ts
+++ b/packages/codemate-plugin/plugins/tags-config/index.ts
@@ -1,0 +1,11 @@
+import { Context, Handler } from 'hydrooj';
+
+class ProblemTagsHandler extends Handler {
+    async get() {
+        this.response.body = { problem_tags: this.domain.problem_tags };
+    }
+}
+
+export async function apply(ctx: Context) {
+    ctx.Route('problem_tags', '/problem_tags_config', ProblemTagsHandler);
+}

--- a/packages/hydrooj/src/error.ts
+++ b/packages/hydrooj/src/error.ts
@@ -156,6 +156,7 @@ export const NotLaunchedByPM2Error = Err('NotLaunchedByPM2Error', BadRequestErro
 export const FileTooLargeError = Err('FileTooLargeError', ValidationError, 'The uploaded file is too long.');
 
 export const ProblemNotApprovedError = Err('ProblemNotApprovedError', ForbiddenError, 'Problem {0} is not approved.');
+export const IncorrectJSONStringError = Err('IncorrectJSONStringError', ForbiddenError, 'String {0} is not a valid JSON string.');
 
 global.Hydro.error = module.exports;
 

--- a/packages/hydrooj/src/handler/domain.ts
+++ b/packages/hydrooj/src/handler/domain.ts
@@ -80,7 +80,7 @@ class DomainEditHandler extends ManageHandler {
 
     async post(args) {
         if (args.operation) return;
-        const $set = {};
+        const $set = { problem_tags: '[]' };
         for (const key in args) {
             if (key === 'problem_tags') {
                 try {

--- a/packages/hydrooj/src/handler/domain.ts
+++ b/packages/hydrooj/src/handler/domain.ts
@@ -1,4 +1,4 @@
-import { GroupModel } from 'codemate-plugin';
+import { GroupModel, logger } from 'codemate-plugin';
 import { load } from 'js-yaml';
 import { Dictionary } from 'lodash';
 import moment from 'moment-timezone';
@@ -9,7 +9,9 @@ import {
     DomainJoinAlreadyMemberError,
     DomainJoinForbiddenError,
     ForbiddenError,
+    IncorrectJSONStringError,
     InvalidJoinInvitationCodeError,
+    InvalidTokenError,
     OnlyOwnerCanDeleteDomainError,
     PermissionError,
     RoleAlreadyExistError,
@@ -80,6 +82,14 @@ class DomainEditHandler extends ManageHandler {
         if (args.operation) return;
         const $set = {};
         for (const key in args) {
+            if (key === 'problem_tags') {
+                try {
+                    const parsedJSON = JSON.parse(args[key]);
+                    args[key] = JSON.stringify(parsedJSON);
+                } catch (error) {
+                    throw new IncorrectJSONStringError(args[key]);
+                }
+            }
             if (DOMAIN_SETTINGS_BY_KEY[key]) $set[key] = args[key];
         }
         await domain.edit(args.domainId, $set);

--- a/packages/hydrooj/src/interface.ts
+++ b/packages/hydrooj/src/interface.ts
@@ -462,6 +462,7 @@ export interface DomainDoc extends Record<string, any> {
     bulletin: string;
     _join?: any;
     host?: string[];
+    problem_tags: string;
 }
 
 // Message

--- a/packages/hydrooj/src/model/setting.ts
+++ b/packages/hydrooj/src/model/setting.ts
@@ -229,6 +229,7 @@ DomainSetting(
     Setting('setting_domain', 'share', '', 'text', 'Share problem with domain (* for any)'),
     Setting('setting_domain', 'bulletin', '', 'markdown', 'Bulletin'),
     Setting('setting_domain', 'langs', '', 'text', 'Allowed langs', null),
+    Setting('setting_domain', 'problem_tags', '[]', 'textarea', 'Problem Tags', 'Input problem tags as JSON string.'),
     Setting('setting_storage', 'host', '', 'text', 'Custom host', null, FLAG_HIDDEN | FLAG_DISABLED),
 );
 


### PR DESCRIPTION
## Proof of Done

### Problem Tag JSON Config

在域设置编辑中，新增Problem Tags配置编辑框，支持输入JSON格式

<img width="884" alt="image" src="https://github.com/user-attachments/assets/4b9c8d90-36da-4886-a688-b9fa74eedae8">

一个示例JSON：
[labels.json](https://github.com/user-attachments/files/16941488/labels.json)

当新的JSON配置被提交时，后端将验证JSON有效性，压缩空字符和回车，存入数据库

### API for JSON Config

GET /problem_tags_config
