### PR TITLE
feat: add tts api

### DIFF
--- a/packages/codemate-plugin/package.json
+++ b/packages/codemate-plugin/package.json
@@ -10,6 +10,7 @@
         "lru-cache": "^10.2.0",
         "nanoid": "^5.0.6",
         "tencentcloud-sdk-nodejs-captcha": "^4.0.850",
+        "tencentcloud-sdk-nodejs-tts": "^4.0.1003",
         "wechatpay-node-v3": "2.1.8"
     },
     "module": "api.ts",

--- a/packages/codemate-plugin/plugins/tts/index.ts
+++ b/packages/codemate-plugin/plugins/tts/index.ts
@@ -1,0 +1,50 @@
+import * as TencentCloudSDK from 'tencentcloud-sdk-nodejs-tts';
+import type { Client as TtsClientType } from 'tencentcloud-sdk-nodejs-tts/tencentcloud/services/tts/v20190823/tts_client';
+import { Context, Handler, nanoid, param, SettingModel, SystemModel, Types } from 'hydrooj';
+
+declare module 'hydrooj' {
+    interface Lib {
+        tts: TtsClientType;
+    }
+}
+
+class TtsHandler extends Handler {
+    @param('text', Types.String)
+    async get(domainId: string, text: string) {
+        const sessionId = nanoid();
+
+        const res = await global.Hydro.lib.tts.TextToVoice({
+            Text: text,
+            SessionId: sessionId,
+            Codec: 'mp3',
+            VoiceType: 601009,
+        });
+
+        this.response.body = {
+            b64AudioMp3File: res.Audio,
+            qCloudSessionId: sessionId,
+        };
+    }
+}
+
+export async function apply(ctx: Context) {
+    ctx.Route('tts', '/tts', TtsHandler);
+
+    ctx.inject(['setting'], (c) => {
+        c.setting.SystemSetting(SettingModel.Setting('setting_secrets', 'tts.secretId', '', 'text', 'TTS SecretId'));
+        c.setting.SystemSetting(SettingModel.Setting('setting_secrets', 'tts.secretKey', '', 'text', 'TTS SecretKey'));
+    });
+
+    global.Hydro.lib.tts = new TencentCloudSDK.tts.v20190823.Client({
+        credential: {
+            secretId: await SystemModel.get('tts.secretId'),
+            secretKey: await SystemModel.get('tts.secretKey'),
+        },
+        region: '',
+        profile: {
+            httpProfile: {
+                endpoint: 'tts.tencentcloudapi.com',
+            },
+        },
+    });
+}


### PR DESCRIPTION
## 接入步骤

1. 腾讯云账号在 https://console.cloud.tencent.com/tts 上开通 TTS 服务。
2. 账号在 https://console.cloud.tencent.com/tts/settings 页面切换至后付费模式。
3. 在 https://console.cloud.tencent.com/cam/user/create?systemType=SubAccount 页面添加子用户，启用编程访问，并分配 `QcloudTTSFullAccess` 权限。
4. 记录 `SecretId` 和 `SecretKey`。
5. 在后台系统管理中填入 tts.secretId 和 tts.secretKey。
6. 重启 Hydro 服务。

## 调用格式

GET /tts

### 请求参数

| 参数 | 类型 | 说明 |
| -- | -- | -- |
| text | string | 需要转语音的文本 |

### 返回格式

| 参数 | 类型 | 说明 |
| -- | -- | -- |
| b64AudioMp3File | string | base64 编码的 mp3 音频文件 |
| qCloudSessionId | string | 腾讯云请求时所用的 SessionId |
